### PR TITLE
Update dependencies 

### DIFF
--- a/antiscroll_rails.gemspec
+++ b/antiscroll_rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_dependency "railties", ">= 3.1"
-  spec.add_dependency "jquery-mousewheel_rails", "~>3.1.11"
+  spec.add_dependency "jquery-mousewheel-rails", "~>3.1.12"
 end

--- a/antiscroll_rails.gemspec
+++ b/antiscroll_rails.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"
   spec.add_dependency "railties", ">= 3.1"
-  spec.add_dependency "jquery-mousewheel-rails", "~>3.1.12"
+  spec.add_dependency "jquery-mousewheel-rails"
 end


### PR DESCRIPTION
"jquery-mousewheel_rails" doesn't exist anymore, it's "jquery-mousewheel-rails" now.
